### PR TITLE
Playback info server hard code

### DIFF
--- a/src/main/java/com/google/step/YTLounge/servlets/PlaybackCalls.java
+++ b/src/main/java/com/google/step/YTLounge/servlets/PlaybackCalls.java
@@ -14,10 +14,7 @@
 
 package com.google.step.YTLounge.servlets;
 
-import com.google.appengine.api.datastore.Entity;
-import com.google.appengine.api.datastore.Key;
-import com.google.appengine.api.datastore.DatastoreService;
-import com.google.appengine.api.datastore.DatastoreServiceFactory;
+import com.google.appengine.api.datastore.*;
 import com.google.gson.Gson;
 import java.io.IOException;
 import javax.servlet.annotation.WebServlet;

--- a/src/main/java/com/google/step/YTLounge/servlets/PlaybackCalls.java
+++ b/src/main/java/com/google/step/YTLounge/servlets/PlaybackCalls.java
@@ -14,11 +14,10 @@
 
 package com.google.step.YTLounge.servlets;
 
+import com.google.appengine.api.datastore.Entity;
+import com.google.appengine.api.datastore.Key;
 import com.google.appengine.api.datastore.DatastoreService;
 import com.google.appengine.api.datastore.DatastoreServiceFactory;
-
-import com.google.appengine.api.datastore.Key;
-import com.google.appengine.api.datastore.Entity;
 import com.google.gson.Gson;
 import java.io.IOException;
 import javax.servlet.annotation.WebServlet;

--- a/src/main/java/com/google/step/YTLounge/servlets/PlaybackCalls.java
+++ b/src/main/java/com/google/step/YTLounge/servlets/PlaybackCalls.java
@@ -17,14 +17,9 @@ package com.google.step.YTLounge.servlets;
 import com.google.appengine.api.datastore.DatastoreService;
 import com.google.appengine.api.datastore.DatastoreServiceFactory;
 import com.google.appengine.api.datastore.Key;
-import com.google.appengine.api.datastore.KeyFactory;
-import com.google.appengine.api.datastore.KeyRange;
-import com.google.appengine.api.users.UserService;
-import com.google.appengine.api.users.UserServiceFactory;
 import com.google.appengine.api.datastore.Entity;
 import com.google.gson.Gson;
 import java.io.IOException;
-import javax.servlet.ServletException;
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
@@ -93,9 +88,9 @@ public class PlaybackCalls extends HttpServlet {
     DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
     Entity entity = null;
     try {
-    entity = datastore.get(videoKey);
+      entity = datastore.get(videoKey);
     } catch (Exception e) {
-        e.printStackTrace();
+      e.printStackTrace();
     }
     double timestamp = (double) entity.getProperty("Timestamp");
     boolean isPlaying = (boolean) entity.getProperty("isPlaying");
@@ -104,7 +99,7 @@ public class PlaybackCalls extends HttpServlet {
     vid.setVideoSpeed(videoSpeed); 
     vid.setIsPlaying(isPlaying); 
     if (isPlaying) { // Only change the timestamp if the video is playing
-      timestamp+= (FETCH_PERIOD/NUM_VIEWERS) * videoSpeed; 
+      timestamp += (FETCH_PERIOD / NUM_VIEWERS) * videoSpeed; 
       entity.setProperty("Timestamp", timestamp);
       datastore.put(entity);
     }  
@@ -115,8 +110,7 @@ public class PlaybackCalls extends HttpServlet {
 
   private boolean getIsPlaying(HttpServletRequest request) {
     String isPlayingString = request.getParameter("isPlaying"); 
-    if (isPlayingString.equals("true")) return true; 
-    return false; 
+    return (isPlayingString.equals("true")); 
   }
 
   private double getTimestamp(HttpServletRequest request) {

--- a/src/main/java/com/google/step/YTLounge/servlets/PlaybackCalls.java
+++ b/src/main/java/com/google/step/YTLounge/servlets/PlaybackCalls.java
@@ -34,10 +34,14 @@ public class PlaybackCalls extends HttpServlet {
 
   /** A YouTube video's data and relevant information */
   private static class PlaybackInfo {
-    private double timestamp; private boolean isPlaying; private double videoSpeed; 
+    private double timestamp;
+    private boolean isPlaying;
+    private double videoSpeed;
 
     public PlaybackInfo() {
-      timestamp = 0; isPlaying = false; videoSpeed = 1; 
+      timestamp = 0;
+      isPlaying = false;
+      videoSpeed = 1;
     }
 
     public void setTimestamp(double timestamp) {
@@ -57,7 +61,7 @@ public class PlaybackCalls extends HttpServlet {
   @Override
   public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
     DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
-    Entity newVideo = null; 
+    Entity newVideo = null;
     if (videoKey != null) { // A video has been started and stored
       try {
         newVideo = datastore.get(videoKey);
@@ -98,7 +102,7 @@ public class PlaybackCalls extends HttpServlet {
       timestamp += (FETCH_PERIOD / NUM_VIEWERS) * videoSpeed;
       entity.setProperty("Timestamp", timestamp);
       datastore.put(entity);
-    } 
+    }
     vid.setTimestamp(timestamp);
     response.setContentType("application/json;");
     response.getWriter().println(convertToJsonUsingGson(vid));

--- a/src/main/java/com/google/step/YTLounge/servlets/PlaybackCalls.java
+++ b/src/main/java/com/google/step/YTLounge/servlets/PlaybackCalls.java
@@ -34,25 +34,21 @@ public class PlaybackCalls extends HttpServlet {
 
   /** A YouTube video's data and relevant information */
   private static class PlaybackInfo {
-    private double timestamp; 
-    private boolean isPlaying; 
-    private double videoSpeed; 
+    private double timestamp; private boolean isPlaying; private double videoSpeed; 
 
     public PlaybackInfo() {
-      timestamp = 0; 
-      isPlaying = false; 
-      videoSpeed = 1; 
+      timestamp = 0; isPlaying = false; videoSpeed = 1; 
     }
 
-    public void setTimestamp (double timestamp) {
+    public void setTimestamp(double timestamp) {
       this.timestamp = timestamp;
     }
 
-    public void setIsPlaying (boolean isPlaying) {
+    public void setIsPlaying(boolean isPlaying) {
       this.isPlaying = isPlaying;
     }
 
-    public void setVideoSpeed (double videoSpeed) {
+    public void setVideoSpeed(double videoSpeed) {
       this.videoSpeed = videoSpeed;
     }
   }
@@ -76,7 +72,7 @@ public class PlaybackCalls extends HttpServlet {
       newVideo.setProperty("Timestamp", 0.0);
       newVideo.setProperty("isPlaying", true);
       newVideo.setProperty("videoSpeed", 1.0);
-      videoKey = newVideo.getKey(); 
+      videoKey = newVideo.getKey();
     }
     datastore.put(newVideo);
     response.sendRedirect("/index.html");
@@ -96,31 +92,28 @@ public class PlaybackCalls extends HttpServlet {
     boolean isPlaying = (boolean) entity.getProperty("isPlaying");
     double videoSpeed = (double) entity.getProperty("videoSpeed");
     PlaybackInfo vid = new PlaybackInfo();
-    vid.setVideoSpeed(videoSpeed); 
-    vid.setIsPlaying(isPlaying); 
+    vid.setVideoSpeed(videoSpeed);
+    vid.setIsPlaying(isPlaying);
     if (isPlaying) { // Only change the timestamp if the video is playing
-      timestamp += (FETCH_PERIOD / NUM_VIEWERS) * videoSpeed; 
+      timestamp += (FETCH_PERIOD / NUM_VIEWERS) * videoSpeed;
       entity.setProperty("Timestamp", timestamp);
       datastore.put(entity);
-    }  
-    vid.setTimestamp(timestamp); 
+    } 
+    vid.setTimestamp(timestamp);
     response.setContentType("application/json;");
     response.getWriter().println(convertToJsonUsingGson(vid));
   }
 
   private boolean getIsPlaying(HttpServletRequest request) {
-    String isPlayingString = request.getParameter("isPlaying"); 
-    return (isPlayingString.equals("true")); 
+    return (request.getParameter("isPlaying").equals("true"));
   }
 
   private double getTimestamp(HttpServletRequest request) {
-    String timestampString = request.getParameter("timestamp"); 
-    return Double.parseDouble(timestampString);
+    return Double.parseDouble(request.getParameter("timestamp"));
   }
 
   private double getVideoSpeed(HttpServletRequest request) {
-    String videoSpeedString = request.getParameter("videoSpeed"); 
-    return Double.parseDouble(videoSpeedString); 
+    return Double.parseDouble(request.getParameter("videoSpeed"));
   }
 
   private String convertToJsonUsingGson(PlaybackInfo input) {

--- a/src/main/java/com/google/step/YTLounge/servlets/PlaybackCalls.java
+++ b/src/main/java/com/google/step/YTLounge/servlets/PlaybackCalls.java
@@ -1,0 +1,137 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.step.YTLounge.servlets;
+
+import com.google.appengine.api.datastore.DatastoreService;
+import com.google.appengine.api.datastore.DatastoreServiceFactory;
+import com.google.appengine.api.datastore.Key;
+import com.google.appengine.api.datastore.KeyFactory;
+import com.google.appengine.api.datastore.KeyRange;
+import com.google.appengine.api.users.UserService;
+import com.google.appengine.api.users.UserServiceFactory;
+import com.google.appengine.api.datastore.Entity;
+import com.google.gson.Gson;
+import java.io.IOException;
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/** Servlet that handles searches. */
+@WebServlet("/PlaybackInfo")
+public class PlaybackCalls extends HttpServlet {
+  private Key videoKey; // Key to the datastore PlaybackInfo entity
+  private int NUM_VIEWERS = 2; // Number of viewers watching video
+  private double FETCH_PERIOD = 1.5; // time between fetch calls
+
+  /** A YouTube video's data and relevant information */
+  private static class PlaybackInfo {
+    private double timestamp; 
+    private boolean isPlaying; 
+    private double videoSpeed; 
+
+    public PlaybackInfo() {
+      timestamp = 0; 
+      isPlaying = false; 
+      videoSpeed = 1; 
+    }
+
+    public void setTimestamp (double timestamp) {
+      this.timestamp = timestamp;
+    }
+
+    public void setIsPlaying (boolean isPlaying) {
+      this.isPlaying = isPlaying;
+    }
+
+    public void setVideoSpeed (double videoSpeed) {
+      this.videoSpeed = videoSpeed;
+    }
+  }
+
+  // Called when users pause, play, seek, or change playback speed
+  @Override
+  public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
+    DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
+    Entity newVideo = null; 
+    if (videoKey != null) { // A video has been started and stored
+      try {
+        newVideo = datastore.get(videoKey);
+      } catch (Exception e) {
+        e.printStackTrace();
+      }
+      newVideo.setProperty("Timestamp", getTimestamp(request));
+      newVideo.setProperty("isPlaying", getIsPlaying(request));
+      newVideo.setProperty("videoSpeed", getVideoSpeed(request));
+    } else { // This is a new video which needs to be stored
+      newVideo = new Entity("Video");
+      newVideo.setProperty("Timestamp", 0.0);
+      newVideo.setProperty("isPlaying", true);
+      newVideo.setProperty("videoSpeed", 1.0);
+      videoKey = newVideo.getKey(); 
+    }
+    datastore.put(newVideo);
+    response.sendRedirect("/index.html");
+  }
+
+  // Called once per fetch period for each client, sends updated video information
+  @Override
+  public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
+    DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
+    Entity entity = null;
+    try {
+    entity = datastore.get(videoKey);
+    } catch (Exception e) {
+        e.printStackTrace();
+    }
+    double timestamp = (double) entity.getProperty("Timestamp");
+    boolean isPlaying = (boolean) entity.getProperty("isPlaying");
+    double videoSpeed = (double) entity.getProperty("videoSpeed");
+    PlaybackInfo vid = new PlaybackInfo();
+    vid.setVideoSpeed(videoSpeed); 
+    vid.setIsPlaying(isPlaying); 
+    if (isPlaying) { // Only change the timestamp if the video is playing
+      timestamp+= (FETCH_PERIOD/NUM_VIEWERS) * videoSpeed; 
+      entity.setProperty("Timestamp", timestamp);
+      datastore.put(entity);
+    }  
+    vid.setTimestamp(timestamp); 
+    response.setContentType("application/json;");
+    response.getWriter().println(convertToJsonUsingGson(vid));
+  }
+
+  private boolean getIsPlaying(HttpServletRequest request) {
+    String isPlayingString = request.getParameter("isPlaying"); 
+    if (isPlayingString.equals("true")) return true; 
+    return false; 
+  }
+
+  private double getTimestamp(HttpServletRequest request) {
+    String timestampString = request.getParameter("timestamp"); 
+    return Double.parseDouble(timestampString);
+  }
+
+  private double getVideoSpeed(HttpServletRequest request) {
+    String videoSpeedString = request.getParameter("videoSpeed"); 
+    return Double.parseDouble(videoSpeedString); 
+  }
+
+  private String convertToJsonUsingGson(PlaybackInfo input) {
+    Gson gson = new Gson();
+    String json = gson.toJson(input);
+    return json;
+  }
+}

--- a/src/main/java/com/google/step/YTLounge/servlets/PlaybackCalls.java
+++ b/src/main/java/com/google/step/YTLounge/servlets/PlaybackCalls.java
@@ -16,6 +16,7 @@ package com.google.step.YTLounge.servlets;
 
 import com.google.appengine.api.datastore.DatastoreService;
 import com.google.appengine.api.datastore.DatastoreServiceFactory;
+
 import com.google.appengine.api.datastore.Key;
 import com.google.appengine.api.datastore.Entity;
 import com.google.gson.Gson;

--- a/src/main/webapp/IFrame.js
+++ b/src/main/webapp/IFrame.js
@@ -128,9 +128,9 @@ function updateVideo(text) {
     player.setPlaybackRate(videoInfo.videoSpeed);
   }
   if (!timesInRange(videoInfo.timestamp)) {
-    player.seekTo(videoInfo.timestamp - 
+    player.seekTo(videoInfo.timestamp -
       ((FETCH_PERIOD / NUM_MEMBERS) * player.getPlaybackRate()), true);
-    player.playVideo(); 
+    player.playVideo();
   } else { // Only updates play state on play/pause, not seek
     if (differentStates(videoInfo.isPlaying)) {
       switch (videoInfo.isPlaying) {


### PR DESCRIPTION
I'm not sure if this is the best way to store the playback info (in a separate datastore from information about the room), but I wasn't sure if I could/how to connect with a datastore on a different link. I also wasn't sure if there was a way to combine this servlet with the SingleVideoSearch.java file, so that may be a better implementation. I believe once the commit with the pom file dependencies goes through, y'all should be able to open up two windows from the dev server and test the vid sync. Notes: 1. Sometimes the fetch request comes in just as you're clicking so you have to press the action again for it to go through. 2. I haven't yet figured out moving the play-head while the video is paused, so if you're testing moving around in the video, you'll have to scroll while the video is on play rather than paused. 3. I don't have the auto-play set up, so you'll have to press play on both videos individually. 4. Playing around with some of the time constants might improve the playback (on different days, different combinations work better for me)