### PR TITLE
Change how links are generated

### DIFF
--- a/src/main/webapp/queue.js
+++ b/src/main/webapp/queue.js
@@ -41,7 +41,7 @@ function updateShareTab() {
       '</button>' +
       '</div>' +
       '<input id="loungeLink" value="https://www.youtube-lounge.appspot.com/' +
-      'lounge.html/?room_id='+ roomParameters +'" type="text" readonly</input>';
+      'lounge.html?room_id='+ roomParameters +'" type="text" readonly</input>';
 }
 
 

--- a/src/main/webapp/start.js
+++ b/src/main/webapp/start.js
@@ -4,7 +4,7 @@ let startButtonCount = 0;
 // Takes the user to the lounge page when the start button is pressed
 async function startRoom() {
   if (startButtonCount < 1) {
-    db.collection('rooms').add({ // eslint-disable-line no-undef
+    await db.collection('rooms').add({ // eslint-disable-line no-undef
       duration: '0',
       elapsedTime: '0',
     })
@@ -22,7 +22,7 @@ async function startRoom() {
               }).catch(function(error) {
                 console.error('Error writing Playback: ', error);
               });
-          window.location.href = 'lounge.html/?room_id=' + docRef.id;
+          window.location.href = 'lounge.html?room_id=' + docRef.id;
         });
     startButtonCount++;
   }


### PR DESCRIPTION
Initially there was a "/" where there shouldn't have been, resulting in the deployment of this project often throwing a 404 error. By removing this character, we can now properly load a user's room. We also make sure that room generation finishes before attempting to change the window's location so that user's aren't taken to an error screen if the page loads before a room is created.